### PR TITLE
feat: add automated daily alert generation with Vercel Cron

### DIFF
--- a/apps/web/app/api/cron/daily-alerts/route.ts
+++ b/apps/web/app/api/cron/daily-alerts/route.ts
@@ -1,0 +1,63 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { headers } from 'next/headers'
+import { generateAlerts } from '@/features/alerts/actions/alert-actions'
+
+export async function GET(request: NextRequest) {
+  try {
+    // Verify the request is from Vercel Cron
+    const headersList = headers()
+    const authorization = headersList.get('authorization')
+    
+    // Check for Vercel Cron secret
+    const cronSecret = process.env.CRON_SECRET
+    if (!cronSecret) {
+      console.error('CRON_SECRET environment variable not set')
+      return NextResponse.json(
+        { error: 'Cron secret not configured' },
+        { status: 500 }
+      )
+    }
+
+    // Verify authorization
+    if (authorization !== `Bearer ${cronSecret}`) {
+      console.error('Unauthorized cron request')
+      return NextResponse.json(
+        { error: 'Unauthorized' },
+        { status: 401 }
+      )
+    }
+
+    console.log('🕐 Starting daily alert generation...')
+    
+    // Generate all alerts
+    const result = await generateAlerts()
+    
+    console.log(`✅ Daily alerts completed: ${result.generated} generated, ${result.resolved} resolved`)
+    
+    return NextResponse.json({
+      success: true,
+      message: 'Daily alerts generated successfully',
+      data: {
+        generated: result.generated,
+        resolved: result.resolved,
+        errors: result.errors
+      },
+      timestamp: new Date().toISOString()
+    })
+
+  } catch (error) {
+    console.error('❌ Cron job error:', error)
+    
+    return NextResponse.json({
+      success: false,
+      message: 'Internal server error during alert generation',
+      error: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString()
+    }, { status: 500 })
+  }
+}
+
+// Only allow GET method
+export async function POST() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 })
+}

--- a/apps/web/app/api/cron/test-alerts/route.ts
+++ b/apps/web/app/api/cron/test-alerts/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server'
+import { generateAlerts } from '@/features/alerts/actions/alert-actions'
+
+// Manual test endpoint for alert generation (no auth required for testing)
+export async function GET() {
+  try {
+    console.log('🧪 Testing alert generation manually...')
+    
+    // Generate all alerts
+    const result = await generateAlerts()
+    
+    console.log(`✅ Test alerts completed: ${result.generated} generated, ${result.resolved} resolved`)
+    
+    return NextResponse.json({
+      success: true,
+      message: 'Test alert generation completed successfully',
+      data: {
+        generated: result.generated,
+        resolved: result.resolved,
+        errors: result.errors
+      },
+      timestamp: new Date().toISOString(),
+      note: 'This is a test endpoint. Production uses /api/cron/daily-alerts with authentication.'
+    })
+
+  } catch (error) {
+    console.error('❌ Test alert generation error:', error)
+    
+    return NextResponse.json({
+      success: false,
+      message: 'Test alert generation failed',
+      error: error instanceof Error ? error.message : 'Unknown error',
+      timestamp: new Date().toISOString()
+    }, { status: 500 })
+  }
+}
+
+export async function POST() {
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 })
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -2,5 +2,11 @@
   "framework": "nextjs",
   "buildCommand": "cd ../.. && pnpm build --filter=web...",
   "installCommand": "cd ../.. && pnpm install",
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "crons": [
+    {
+      "path": "/api/cron/daily-alerts",
+      "schedule": "0 6 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
- Add /api/cron/daily-alerts endpoint with CRON_SECRET authentication
- Add /api/cron/test-alerts endpoint for manual testing
- Configure Vercel Cron to run daily at 6:00 AM UTC
- Add comprehensive CRON_SETUP.md documentation
- Implement secure alert generation automation
- Enable production-ready automated inventory monitoring